### PR TITLE
logging updates for CS 4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 01 December 2025
+
+### Changed
+
+* Updated the cobalt_parser to handle new <task val> fields in Cobalt Strike 4.12 logs
+* Updated the cobalt_web to create tags in Ghostwriter based on the MITRE fields from Cobalt Strike logs
+* Updated the cobalt_web to set the new task identifiers from CS4.12 in the output field in Ghostwriter logs
+
 ## [2.0.4] - 08 April 2024
 
 ### Changed

--- a/cobalt_web/cobalt_web.py
+++ b/cobalt_web/cobalt_web.py
@@ -425,10 +425,9 @@ class CobaltSync:
                     add_tags = await self._execute_query(self.addTags_mutation, {
                         "id": result["insert_oplogEntry"]["returning"][0]["id"],
                         "model": "oplog_entry",
-                        "tags":  [f"ATT&CK:{t}" for t in message["mitre"]]
+                        "tags": [f"ATT&CK:{t}" for t in message["mitre"]]
                     })
                     cobalt_sync_log.info("added tags: %s", add_tags)
-                pass
             else:
                 cobalt_sync_log.info(
                     "Did not receive a response with data from Ghostwriter's GraphQL API! Response: %s",


### PR DESCRIPTION
## [2.0.5] - 01 December 2025

### Changed

* Updated the cobalt_parser to handle new <task val> fields in Cobalt Strike 4.12 logs
* Updated the cobalt_web to create tags in Ghostwriter based on the MITRE fields from Cobalt Strike logs
* Updated the cobalt_web to set the new task identifiers from CS4.12 in the output field in Ghostwriter logs